### PR TITLE
Spark DFs are not ordered

### DIFF
--- a/ons-spark/_toc.yml
+++ b/ons-spark/_toc.yml
@@ -32,6 +32,7 @@ parts:
   - file: spark-functions/arrays
   - file: spark-functions/writing-data
   - file: spark-functions/job-description
+  - file: spark-functions/sorting-data
 - caption: Understanding and Optimising Spark
   chapters:
   - file: spark-concepts/spark-application-and-ui

--- a/ons-spark/raw-notebooks/df-order/df-order.ipynb
+++ b/ons-spark/raw-notebooks/df-order/df-order.ipynb
@@ -157,7 +157,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now preview this DataFrame several times.Remember that in Spark, the whole plan will be processed, so it will create and order the DataFrame by `nation` each time, but not the `year`, and so this may be different:"
+    "Now preview this DataFrame several times. Remember that in Spark, the whole plan will be processed, so it will create and order the DataFrame by `nation` each time, but not the `year`, and so this may be different:"
    ]
   },
   {

--- a/ons-spark/raw-notebooks/df-order/df-order.ipynb
+++ b/ons-spark/raw-notebooks/df-order/df-order.ipynb
@@ -1,0 +1,409 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Spark DataFrames Are Not Ordered\n",
+    "\n",
+    "Spark DataFrames do not have the order preserved in the same way as pandas or base R DataFrames. Subsetting a pandas or R DataFrame, e.g. with `head()`, will always return identical rows, whereas the rows returned may be different when subsetting PySpark or sparklyr DFs, e.g with [`.show()`](https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.DataFrame.show.html) or `head()`.\n",
+    "\n",
+    "The reason for this is that Spark DataFrames are distributed across partitions. Some operations, such as joining, grouping or sorting, cause data to be moved between [partitions](../spark-concepts/partitions), known as a [*shuffle*](../spark-concepts/shuffling). Running the exact same Spark code can result in different data being on different partitions, as well as a different order within each partition.\n",
+    "\n",
+    "### Why Spark DFs are not ordered\n",
+    "\n",
+    "The lack of an order in a Spark DataFrame is due to two related concepts: partitioning and lazy evaluation.\n",
+    "\n",
+    "A Spark DataFrame is distributed across partitions on the Spark cluster, rather than being one complete object stored in the driver memory. Executing an identical Spark plan can result in the same rows going to different partitions. Within these partitions, the rows can also be in a different order.\n",
+    "\n",
+    "The lazy evaluation will cause the DataFrame to be re-evaluated each time an action is called. Spark will only do the minimum required to return the result of the action specified, e.g. subsetting and previewing the data with `.show()`/`head() %>% ` [`collect()`](https://dplyr.tidyverse.org/reference/compute.html) may not require evaluation of the whole DataFrame (this can be demonstrated when using [caching](../spark-concepts/cache), as the cache may only be partially filled with these operations). As such, if no order is specified then the data may be returned in a different order, despite the Spark plan being identical. If the data is being subset in a non-specific way, e.g. with `.show()`/`head() %>% collect()`, then different rows may be returned.\n",
+    "\n",
+    "The technical term for this is *non-determinism*, which is where the same algorithm can return different results for the same inputs. This can cause problems when regression testing (ensuring that results are identical after a code change) and unit testing your Spark code with [Pytest](../testing-debugging/unit-testing-pyspark) or [testthat](../testing-debugging/unit-testing-sparklyr).\n",
+    "\n",
+    "The main lesson from this is that if you want to rely on the order of a Spark DataFrame, you need to [explicitly specify the order](../spark-functions/sorting-data); this may involve using a column as a tie-breaker (e.g. a key column such as an ID, which is unique).\n",
+    "\n",
+    "### Does the order really matter?\n",
+    "\n",
+    "Before looking at examples, it is worth remembering that often the order of the data does not matter. Ordering data in Spark is an expensive operation as it requires a [shuffle of the data](../spark-concepts/shuffling), so try to avoid sorting if you can. You may want to aim for only ordering the data when [writing out final results](../spark-functions/writing-data) (e.g. to a CSV if you need the result to be human readable).\n",
+    "\n",
+    "### An example: different order within same partition\n",
+    "\n",
+    "First, create a new Spark session and a small DataFrame; this example uses the winners of the Six Nations rugby union tournament:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "from pyspark.sql import SparkSession, functions as F\n",
+    "\n",
+    "with open(\"../../../config.yaml\") as f:\n",
+    "    config = yaml.safe_load(f)\n",
+    "\n",
+    "spark = (SparkSession.builder.master(\"local[2]\")\n",
+    "         .appName(\"df-order\")\n",
+    "         .config(\"spark.sql.shuffle.partitions\", 12)\n",
+    "         .getOrCreate())\n",
+    "\n",
+    "winners = spark.createDataFrame([\n",
+    "    [2022, \"France\"],\n",
+    "    [2021, \"Wales\"],\n",
+    "    [2020, \"England\"],\n",
+    "    [2019, \"Wales\"],\n",
+    "    [2018, \"Ireland\"],\n",
+    "    [2017, \"England\"],\n",
+    "    [2016, \"England\"],\n",
+    "    [2015, \"Ireland\"],\n",
+    "    [2014, \"Ireland\"],\n",
+    "    [2013, \"Wales\"],\n",
+    "    [2012, \"Wales\"],\n",
+    "    [2011, \"England\"],\n",
+    "    [2010, \"France\"],\n",
+    "    [2009, \"Ireland\"],\n",
+    "    [2008, \"Wales\"],\n",
+    "    [2007, \"France\"],\n",
+    "    [2006, \"France\"],\n",
+    "    [2005, \"Wales\"],\n",
+    "    [2004, \"France\"],\n",
+    "    [2003, \"England\"],\n",
+    "    [2002, \"France\"],\n",
+    "    [2001, \"England\"],\n",
+    "    [2000, \"England\"],\n",
+    "    ],\n",
+    "    [\"year\", \"nation\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```r\n",
+    "library(sparklyr)\n",
+    "library(dplyr)\n",
+    "\n",
+    "config <- yaml::yaml.load_file(\"ons-spark/config.yaml\")\n",
+    "\n",
+    "small_config <- sparklyr::spark_config()\n",
+    "small_config$spark.sql.shuffle.partitions <- 12\n",
+    "small_config$spark.sql.shuffle.partitions.local <- 12\n",
+    "\n",
+    "sc <- sparklyr::spark_connect(\n",
+    "    master = \"local[2]\",\n",
+    "    app_name = \"df-order\",\n",
+    "    config = small_config)\n",
+    "\n",
+    "winners <- sparklyr::sdf_copy_to(sc,\n",
+    "    data.frame(\n",
+    "        \"year\" = 2022:2000,\n",
+    "            \"nation\" = c(\n",
+    "                \"France\",\n",
+    "                \"Wales\",\n",
+    "                \"England\",\n",
+    "                \"Wales\",\n",
+    "                \"Ireland\",\n",
+    "                rep(\"England\", 2),\n",
+    "                rep(\"Ireland\", 2),\n",
+    "                rep(\"Wales\", 2),\n",
+    "                \"England\",\n",
+    "                \"France\",\n",
+    "                \"Ireland\",\n",
+    "                \"Wales\",\n",
+    "                rep(\"France\", 2),\n",
+    "                \"Wales\",\n",
+    "                \"France\",\n",
+    "                \"England\",\n",
+    "                \"France\",\n",
+    "                rep(\"England\", 2))),\n",
+    "    repartition=2)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now order the data by `nation`. This will ensure that the first nation alphabetically will be returned (`England`), but as the `year` is not specified these may be returned in a different order.\n",
+    "\n",
+    "To demonstrate that these rows are all on the same partition, create a new column using [`F.spark_partition_id()`](https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.functions.spark_partition_id.html)/[`spark_partition_id()`](https://spark.apache.org/docs/latest/api/sql/index.html#spark_partition_id):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "winners_ordered = (winners\n",
+    "                   .orderBy(\"nation\")\n",
+    "                   .withColumn(\"partition_id\", F.spark_partition_id()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```r\n",
+    "winners_ordered <- winners %>%\n",
+    "    sparklyr::sdf_sort(c(\"nation\")) %>%\n",
+    "    sparklyr::mutate(partition_id = spark_partition_id())\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now preview this DataFrame several times.Remember that in Spark, the whole plan will be processed, so it will create and order the DataFrame by `nation` each time, but not the `year`, and so this may be different:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+----+-------+------------+\n",
+      "|year| nation|partition_id|\n",
+      "+----+-------+------------+\n",
+      "|2020|England|           0|\n",
+      "|2017|England|           0|\n",
+      "|2016|England|           0|\n",
+      "|2011|England|           0|\n",
+      "|2003|England|           0|\n",
+      "+----+-------+------------+\n",
+      "only showing top 5 rows\n",
+      "\n",
+      "+----+-------+------------+\n",
+      "|year| nation|partition_id|\n",
+      "+----+-------+------------+\n",
+      "|2011|England|           0|\n",
+      "|2020|England|           0|\n",
+      "|2016|England|           0|\n",
+      "|2017|England|           0|\n",
+      "|2003|England|           0|\n",
+      "+----+-------+------------+\n",
+      "only showing top 5 rows\n",
+      "\n",
+      "+----+-------+------------+\n",
+      "|year| nation|partition_id|\n",
+      "+----+-------+------------+\n",
+      "|2020|England|           0|\n",
+      "|2017|England|           0|\n",
+      "|2016|England|           0|\n",
+      "|2011|England|           0|\n",
+      "|2003|England|           0|\n",
+      "+----+-------+------------+\n",
+      "only showing top 5 rows\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "for show_no in range(3):\n",
+    "    winners_ordered.show(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```r\n",
+    "for(show_no in 1:3){\n",
+    "    winners_ordered %>%\n",
+    "    head(5) %>%\n",
+    "    sparklyr::collect() %>%\n",
+    "    print()\n",
+    "}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The results not all the same. The data in the `nation` column is identical every time, as this was explicitly ordered, but the `year` is not.\n",
+    "\n",
+    "This demonstrates that the data is being returned in `partition_id` order for each `nation`, but there is no fixed ordering within each partition. If the DataFrame was also sorted by `year` the same result would be returned each time.\n",
+    "\n",
+    "Note that if you run the code again, you may get different results.\n",
+    "\n",
+    "### Another example: different `partition_id`\n",
+    "\n",
+    "During a shuffle the data can be sent to different partitions when executing the same Spark plan multiple times.\n",
+    "\n",
+    "First, import the Animal Rescue CSV data and do some data cleansing. The data is also being sorted by `AnimalGroup`; this causes a shuffle which will repartition the data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rescue_path_csv = config[\"rescue_path_csv\"]\n",
+    "rescue = (spark\n",
+    "          .read.csv(rescue_path_csv, header=True, inferSchema=True)\n",
+    "          .withColumnRenamed(\"IncidentNumber\", \"incident_number\")\n",
+    "          .withColumnRenamed(\"AnimalGroupParent\", \"animal_group\")\n",
+    "          .select(\"incident_number\", \"animal_group\")\n",
+    "          .orderBy(\"animal_group\")\n",
+    "         )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```r\n",
+    "rescue <- sparklyr::spark_read_csv(sc,\n",
+    "                                   config$rescue_path_csv,\n",
+    "                                   header=TRUE,\n",
+    "                                   infer_schema=TRUE) %>%\n",
+    "    dplyr:::rename(\n",
+    "        incident_number = IncidentNumber,\n",
+    "        animal_group = AnimalGroupParent) %>%\n",
+    "    sparklyr::select(incident_number, animal_group) %>%\n",
+    "    sparklyr::sdf_sort(c(\"animal_group\"))\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now group the data by `animal_group`, which will cause another shuffle, count how many of each animal there are, and return `Fox`, `Goat` and `Hamster`, then show the result multiple times:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+------------+-----+------------+\n",
+      "|animal_group|count|partition_id|\n",
+      "+------------+-----+------------+\n",
+      "|         Fox|  238|           7|\n",
+      "|        Goat|    1|           8|\n",
+      "|     Hamster|   14|           9|\n",
+      "+------------+-----+------------+\n",
+      "\n",
+      "+------------+-----+------------+\n",
+      "|animal_group|count|partition_id|\n",
+      "+------------+-----+------------+\n",
+      "|         Fox|  238|           8|\n",
+      "|        Goat|    1|           9|\n",
+      "|     Hamster|   14|          10|\n",
+      "+------------+-----+------------+\n",
+      "\n",
+      "+------------+-----+------------+\n",
+      "|animal_group|count|partition_id|\n",
+      "+------------+-----+------------+\n",
+      "|         Fox|  238|           8|\n",
+      "|        Goat|    1|           9|\n",
+      "|     Hamster|   14|          10|\n",
+      "+------------+-----+------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "animal_counts = (rescue\n",
+    "                 .groupBy(\"animal_group\")\n",
+    "                 .count()\n",
+    "                 .withColumn(\"partition_id\", F.spark_partition_id())\n",
+    "                 .filter(F.col(\"animal_group\").isin(\"Fox\", \"Goat\", \"Hamster\")))\n",
+    "\n",
+    "for show_no in range(3):\n",
+    "    animal_counts.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```r\n",
+    "animal_counts <- rescue %>%\n",
+    "    dplyr::group_by(animal_group) %>%\n",
+    "    dplyr::summarise(count = n()) %>%\n",
+    "    sparklyr::mutate(partition_id = spark_partition_id()) %>%\n",
+    "    sparklyr::filter(animal_group %in% c(\"Fox\", \"Goat\", \"Hamster\"))\n",
+    "\n",
+    "for(show_no in 1:3){\n",
+    "    animal_counts %>%\n",
+    "    sparklyr::collect() %>%\n",
+    "    print()\n",
+    "}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Although the same plan is being executed each time, the `partition_id` can be different. The `partition_id` is allocated by the [`.groupBy()`](https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.DataFrame.groupBy.html)/[`group_by()`](https://dplyr.tidyverse.org/reference/group_by.html) operation, which causes a shuffle.\n",
+    "\n",
+    "### Final thoughts\n",
+    "\n",
+    "Remember that sorting the data causes a [shuffle](../spark-concepts/shuffling), which is an expensive operation. Try and only sort data when necessary.\n",
+    "\n",
+    "Sometimes you do want your code to be non-deterministic, e.g. when using random numbers. You can set a seed to replicate results if needed. You may also want to use [mocking](../testing-debugging/unit-testing-pyspark.html#mocking) if unit testing in PySpark with random numbers.\n",
+    "\n",
+    "### Further Resources\n",
+    "\n",
+    "Spark at the ONS Articles:\n",
+    "- [Managing Partitions](../spark-concepts/partitions)\n",
+    "- [Shuffling](../spark-concepts/shuffling)\n",
+    "- [Sorting Spark DataFrames](../spark-functions/sorting-data)\n",
+    "- [Unit Testing in PySpark](../testing-debugging/unit-testing-pyspark)\n",
+    "    - [Mocking](../testing-debugging/unit-testing-pyspark.html#mocking)\n",
+    "- [Unit Testing in sparklyr](../testing-debugging/unit-testing-sparklyr)\n",
+    "- [Caching](../spark-concepts/cache)\n",
+    "- [Writing Data](../spark-functions/writing-data)\n",
+    "\n",
+    "PySpark Documentation:\n",
+    "- [`.show()`](https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.DataFrame.show.html)\n",
+    "- [`F.spark_partition_id()`](https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.functions.spark_partition_id.html)\n",
+    "- [`.groupBy()`](https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.DataFrame.groupBy.html)\n",
+    "\n",
+    "sparklyr and tidyverse Documentation:\n",
+    "- [`group_by()`](https://dplyr.tidyverse.org/reference/group_by.html)\n",
+    "- [`collect()`](https://dplyr.tidyverse.org/reference/compute.html)\n",
+    "\n",
+    "Spark SQL Functions Documentation:\n",
+    "- [`spark_partition_id`](https://spark.apache.org/docs/latest/api/sql/index.html#spark_partition_id)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/ons-spark/raw-notebooks/df-order/outputs.csv
+++ b/ons-spark/raw-notebooks/df-order/outputs.csv
@@ -1,0 +1,103 @@
+cell_no,execution_count,tidy_python_output,r_output
+1,1,,
+4,2,,
+7,3,"+----+-------+------------+
+|year| nation|partition_id|
++----+-------+------------+
+|2020|England|           0|
+|2017|England|           0|
+|2016|England|           0|
+|2011|England|           0|
+|2003|England|           0|
++----+-------+------------+
+only showing top 5 rows
+
++----+-------+------------+
+|year| nation|partition_id|
++----+-------+------------+
+|2011|England|           0|
+|2020|England|           0|
+|2016|England|           0|
+|2017|England|           0|
+|2003|England|           0|
++----+-------+------------+
+only showing top 5 rows
+
++----+-------+------------+
+|year| nation|partition_id|
++----+-------+------------+
+|2020|England|           0|
+|2017|England|           0|
+|2016|England|           0|
+|2011|England|           0|
+|2003|England|           0|
++----+-------+------------+
+only showing top 5 rows
+","# A tibble: 5 × 3
+   year nation  partition_id
+  <int> <chr>          <int>
+1  2001 England            0
+2  2011 England            0
+3  2003 England            0
+4  2000 England            0
+5  2016 England            0
+# A tibble: 5 × 3
+   year nation  partition_id
+  <int> <chr>          <int>
+1  2001 England            0
+2  2011 England            0
+3  2003 England            0
+4  2000 England            0
+5  2016 England            0
+# A tibble: 5 × 3
+   year nation  partition_id
+  <int> <chr>          <int>
+1  2011 England            0
+2  2020 England            0
+3  2016 England            0
+4  2017 England            0
+5  2003 England            0
+"
+10,4,,
+13,5,"+------------+-----+------------+
+|animal_group|count|partition_id|
++------------+-----+------------+
+|         Fox|  238|           7|
+|        Goat|    1|           8|
+|     Hamster|   14|           9|
++------------+-----+------------+
+
++------------+-----+------------+
+|animal_group|count|partition_id|
++------------+-----+------------+
+|         Fox|  238|           8|
+|        Goat|    1|           9|
+|     Hamster|   14|          10|
++------------+-----+------------+
+
++------------+-----+------------+
+|animal_group|count|partition_id|
++------------+-----+------------+
+|         Fox|  238|           8|
+|        Goat|    1|           9|
+|     Hamster|   14|          10|
++------------+-----+------------+
+","# A tibble: 3 × 3
+  animal_group count partition_id
+  <chr>        <dbl>        <int>
+1 Fox            238            8
+2 Goat             1            9
+3 Hamster         14           10
+# A tibble: 3 × 3
+  animal_group count partition_id
+  <chr>        <dbl>        <int>
+1 Fox            238            8
+2 Goat             1            9
+3 Hamster         14            9
+# A tibble: 3 × 3
+  animal_group count partition_id
+  <chr>        <dbl>        <int>
+1 Fox            238            7
+2 Goat             1            8
+3 Hamster         14            8
+"

--- a/ons-spark/raw-notebooks/df-order/r_input.R
+++ b/ons-spark/raw-notebooks/df-order/r_input.R
@@ -1,0 +1,71 @@
+
+library(sparklyr)
+library(dplyr)
+
+config <- yaml::yaml.load_file("ons-spark/config.yaml")
+
+small_config <- sparklyr::spark_config()
+small_config$spark.sql.shuffle.partitions <- 12
+small_config$spark.sql.shuffle.partitions.local <- 12
+
+sc <- sparklyr::spark_connect(
+    master = "local[2]",
+    app_name = "df-order",
+    config = small_config)
+
+winners <- sparklyr::sdf_copy_to(sc,
+    data.frame(
+        "year" = 2022:2000,
+            "nation" = c(
+                "France",
+                "Wales",
+                "England",
+                "Wales",
+                "Ireland",
+                rep("England", 2),
+                rep("Ireland", 2),
+                rep("Wales", 2),
+                "England",
+                "France",
+                "Ireland",
+                "Wales",
+                rep("France", 2),
+                "Wales",
+                "France",
+                "England",
+                "France",
+                rep("England", 2))),
+    repartition=2)
+
+winners_ordered <- winners %>%
+    sparklyr::sdf_sort(c("nation")) %>%
+    sparklyr::mutate(partition_id = spark_partition_id())
+
+for(show_no in 1:3){
+    winners_ordered %>%
+    head(5) %>%
+    sparklyr::collect() %>%
+    print()
+}
+
+rescue <- sparklyr::spark_read_csv(sc,
+                                   config$rescue_path_csv,
+                                   header=TRUE,
+                                   infer_schema=TRUE) %>%
+    dplyr:::rename(
+        incident_number = IncidentNumber,
+        animal_group = AnimalGroupParent) %>%
+    sparklyr::select(incident_number, animal_group) %>%
+    sparklyr::sdf_sort(c("animal_group"))
+
+animal_counts <- rescue %>%
+    dplyr::group_by(animal_group) %>%
+    dplyr::summarise(count = n()) %>%
+    sparklyr::mutate(partition_id = spark_partition_id()) %>%
+    sparklyr::filter(animal_group %in% c("Fox", "Goat", "Hamster"))
+
+for(show_no in 1:3){
+    animal_counts %>%
+    sparklyr::collect() %>%
+    print()
+}

--- a/ons-spark/spark-concepts/df-order.md
+++ b/ons-spark/spark-concepts/df-order.md
@@ -125,7 +125,7 @@ winners_ordered <- winners %>%
 
 ```
 ````
-Now preview this DataFrame several times.Remember that in Spark, the whole plan will be processed, so it will create and order the DataFrame by `nation` each time, but not the `year`, and so this may be different:
+Now preview this DataFrame several times. Remember that in Spark, the whole plan will be processed, so it will create and order the DataFrame by `nation` each time, but not the `year`, and so this may be different:
 ````{tabs}
 ```{code-tab} py
 for show_no in range(3):

--- a/ons-spark/spark-concepts/df-order.md
+++ b/ons-spark/spark-concepts/df-order.md
@@ -1,7 +1,357 @@
-## Spark DFs Are Not Ordered
+## Spark DataFrames Are Not Ordered
 
-```{warning}
-This section is under construction.
+Spark DataFrames do not have the order preserved in the same way as pandas or base R DataFrames. Subsetting a pandas or R DataFrame, e.g. with `head()`, will always return identical rows, whereas the rows returned may be different when subsetting PySpark or sparklyr DFs, e.g with [`.show()`](https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.DataFrame.show.html) or `head()`.
+
+The reason for this is that Spark DataFrames are distributed across partitions. Some operations, such as joining, grouping or sorting, cause data to be moved between [partitions](../spark-concepts/partitions), known as a [*shuffle*](../spark-concepts/shuffling). Running the exact same Spark code can result in different data being on different partitions, as well as a different order within each partition.
+
+### Why Spark DFs are not ordered
+
+The lack of an order in a Spark DataFrame is due to two related concepts: partitioning and lazy evaluation.
+
+A Spark DataFrame is distributed across partitions on the Spark cluster, rather than being one complete object stored in the driver memory. Executing an identical Spark plan can result in the same rows going to different partitions. Within these partitions, the rows can also be in a different order.
+
+The lazy evaluation will cause the DataFrame to be re-evaluated each time an action is called. Spark will only do the minimum required to return the result of the action specified, e.g. subsetting and previewing the data with `.show()`/`head() %>% ` [`collect()`](https://dplyr.tidyverse.org/reference/compute.html) may not require evaluation of the whole DataFrame (this can be demonstrated when using [caching](../spark-concepts/cache), as the cache may only be partially filled with these operations). As such, if no order is specified then the data may be returned in a different order, despite the Spark plan being identical. If the data is being subset in a non-specific way, e.g. with `.show()`/`head() %>% collect()`, then different rows may be returned.
+
+The technical term for this is *non-determinism*, which is where the same algorithm can return different results for the same inputs. This can cause problems when regression testing (ensuring that results are identical after a code change) and unit testing your Spark code with [Pytest](../testing-debugging/unit-testing-pyspark) or [testthat](../testing-debugging/unit-testing-sparklyr).
+
+The main lesson from this is that if you want to rely on the order of a Spark DataFrame, you need to [explicitly specify the order](../spark-functions/sorting-data); this may involve using a column as a tie-breaker (e.g. a key column such as an ID, which is unique).
+
+### Does the order really matter?
+
+Before looking at examples, it is worth remembering that often the order of the data does not matter. Ordering data in Spark is an expensive operation as it requires a [shuffle of the data](../spark-concepts/shuffling), so try to avoid sorting if you can. You may want to aim for only ordering the data when [writing out final results](../spark-functions/writing-data) (e.g. to a CSV if you need the result to be human readable).
+
+### An example: different order within same partition
+
+First, create a new Spark session and a small DataFrame; this example uses the winners of the Six Nations rugby union tournament:
+````{tabs}
+```{code-tab} py
+import yaml
+from pyspark.sql import SparkSession, functions as F
+
+with open("../../../config.yaml") as f:
+    config = yaml.safe_load(f)
+
+spark = (SparkSession.builder.master("local[2]")
+         .appName("df-order")
+         .config("spark.sql.shuffle.partitions", 12)
+         .getOrCreate())
+
+winners = spark.createDataFrame([
+    [2022, "France"],
+    [2021, "Wales"],
+    [2020, "England"],
+    [2019, "Wales"],
+    [2018, "Ireland"],
+    [2017, "England"],
+    [2016, "England"],
+    [2015, "Ireland"],
+    [2014, "Ireland"],
+    [2013, "Wales"],
+    [2012, "Wales"],
+    [2011, "England"],
+    [2010, "France"],
+    [2009, "Ireland"],
+    [2008, "Wales"],
+    [2007, "France"],
+    [2006, "France"],
+    [2005, "Wales"],
+    [2004, "France"],
+    [2003, "England"],
+    [2002, "France"],
+    [2001, "England"],
+    [2000, "England"],
+    ],
+    ["year", "nation"]
+)
 ```
 
+```{code-tab} r R
+
+library(sparklyr)
+library(dplyr)
+
+config <- yaml::yaml.load_file("ons-spark/config.yaml")
+
+small_config <- sparklyr::spark_config()
+small_config$spark.sql.shuffle.partitions <- 12
+small_config$spark.sql.shuffle.partitions.local <- 12
+
+sc <- sparklyr::spark_connect(
+    master = "local[2]",
+    app_name = "df-order",
+    config = small_config)
+
+winners <- sparklyr::sdf_copy_to(sc,
+    data.frame(
+        "year" = 2022:2000,
+            "nation" = c(
+                "France",
+                "Wales",
+                "England",
+                "Wales",
+                "Ireland",
+                rep("England", 2),
+                rep("Ireland", 2),
+                rep("Wales", 2),
+                "England",
+                "France",
+                "Ireland",
+                "Wales",
+                rep("France", 2),
+                "Wales",
+                "France",
+                "England",
+                "France",
+                rep("England", 2))),
+    repartition=2)
+
+```
+````
+Now order the data by `nation`. This will ensure that the first nation alphabetically will be returned (`England`), but as the `year` is not specified these may be returned in a different order.
+
+To demonstrate that these rows are all on the same partition, create a new column using [`F.spark_partition_id()`](https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.functions.spark_partition_id.html)/[`spark_partition_id()`](https://spark.apache.org/docs/latest/api/sql/index.html#spark_partition_id):
+````{tabs}
+```{code-tab} py
+winners_ordered = (winners
+                   .orderBy("nation")
+                   .withColumn("partition_id", F.spark_partition_id()))
+```
+
+```{code-tab} r R
+
+winners_ordered <- winners %>%
+    sparklyr::sdf_sort(c("nation")) %>%
+    sparklyr::mutate(partition_id = spark_partition_id())
+
+```
+````
+Now preview this DataFrame several times.Remember that in Spark, the whole plan will be processed, so it will create and order the DataFrame by `nation` each time, but not the `year`, and so this may be different:
+````{tabs}
+```{code-tab} py
+for show_no in range(3):
+    winners_ordered.show(5)
+```
+
+```{code-tab} r R
+
+for(show_no in 1:3){
+    winners_ordered %>%
+    head(5) %>%
+    sparklyr::collect() %>%
+    print()
+}
+
+```
+````
+
+````{tabs}
+
+```{code-tab} plaintext Python Output
++----+-------+------------+
+|year| nation|partition_id|
++----+-------+------------+
+|2020|England|           0|
+|2017|England|           0|
+|2016|England|           0|
+|2011|England|           0|
+|2003|England|           0|
++----+-------+------------+
+only showing top 5 rows
+
++----+-------+------------+
+|year| nation|partition_id|
++----+-------+------------+
+|2011|England|           0|
+|2020|England|           0|
+|2016|England|           0|
+|2017|England|           0|
+|2003|England|           0|
++----+-------+------------+
+only showing top 5 rows
+
++----+-------+------------+
+|year| nation|partition_id|
++----+-------+------------+
+|2020|England|           0|
+|2017|England|           0|
+|2016|England|           0|
+|2011|England|           0|
+|2003|England|           0|
++----+-------+------------+
+only showing top 5 rows
+```
+
+```{code-tab} plaintext R Output
+# A tibble: 5 × 3
+   year nation  partition_id
+  <int> <chr>          <int>
+1  2001 England            0
+2  2011 England            0
+3  2003 England            0
+4  2000 England            0
+5  2016 England            0
+# A tibble: 5 × 3
+   year nation  partition_id
+  <int> <chr>          <int>
+1  2001 England            0
+2  2011 England            0
+3  2003 England            0
+4  2000 England            0
+5  2016 England            0
+# A tibble: 5 × 3
+   year nation  partition_id
+  <int> <chr>          <int>
+1  2011 England            0
+2  2020 England            0
+3  2016 England            0
+4  2017 England            0
+5  2003 England            0
+```
+````
+The results not all the same. The data in the `nation` column is identical every time, as this was explicitly ordered, but the `year` is not.
+
+This demonstrates that the data is being returned in `partition_id` order for each `nation`, but there is no fixed ordering within each partition. If the DataFrame was also sorted by `year` the same result would be returned each time.
+
+Note that if you run the code again, you may get different results.
+
+### Another example: different `partition_id`
+
+During a shuffle the data can be sent to different partitions when executing the same Spark plan multiple times.
+
+First, import the Animal Rescue CSV data and do some data cleansing. The data is also being sorted by `AnimalGroup`; this causes a shuffle which will repartition the data:
+````{tabs}
+```{code-tab} py
+rescue_path_csv = config["rescue_path_csv"]
+rescue = (spark
+          .read.csv(rescue_path_csv, header=True, inferSchema=True)
+          .withColumnRenamed("IncidentNumber", "incident_number")
+          .withColumnRenamed("AnimalGroupParent", "animal_group")
+          .select("incident_number", "animal_group")
+          .orderBy("animal_group")
+         )
+```
+
+```{code-tab} r R
+
+rescue <- sparklyr::spark_read_csv(sc,
+                                   config$rescue_path_csv,
+                                   header=TRUE,
+                                   infer_schema=TRUE) %>%
+    dplyr:::rename(
+        incident_number = IncidentNumber,
+        animal_group = AnimalGroupParent) %>%
+    sparklyr::select(incident_number, animal_group) %>%
+    sparklyr::sdf_sort(c("animal_group"))
+
+```
+````
+Now group the data by `animal_group`, which will cause another shuffle, count how many of each animal there are, and return `Fox`, `Goat` and `Hamster`, then show the result multiple times:
+````{tabs}
+```{code-tab} py
+animal_counts = (rescue
+                 .groupBy("animal_group")
+                 .count()
+                 .withColumn("partition_id", F.spark_partition_id())
+                 .filter(F.col("animal_group").isin("Fox", "Goat", "Hamster")))
+
+for show_no in range(3):
+    animal_counts.show()
+```
+
+```{code-tab} r R
+
+animal_counts <- rescue %>%
+    dplyr::group_by(animal_group) %>%
+    dplyr::summarise(count = n()) %>%
+    sparklyr::mutate(partition_id = spark_partition_id()) %>%
+    sparklyr::filter(animal_group %in% c("Fox", "Goat", "Hamster"))
+
+for(show_no in 1:3){
+    animal_counts %>%
+    sparklyr::collect() %>%
+    print()
+}
+
+```
+````
+
+````{tabs}
+
+```{code-tab} plaintext Python Output
++------------+-----+------------+
+|animal_group|count|partition_id|
++------------+-----+------------+
+|         Fox|  238|           7|
+|        Goat|    1|           8|
+|     Hamster|   14|           9|
++------------+-----+------------+
+
++------------+-----+------------+
+|animal_group|count|partition_id|
++------------+-----+------------+
+|         Fox|  238|           8|
+|        Goat|    1|           9|
+|     Hamster|   14|          10|
++------------+-----+------------+
+
++------------+-----+------------+
+|animal_group|count|partition_id|
++------------+-----+------------+
+|         Fox|  238|           8|
+|        Goat|    1|           9|
+|     Hamster|   14|          10|
++------------+-----+------------+
+```
+
+```{code-tab} plaintext R Output
+# A tibble: 3 × 3
+  animal_group count partition_id
+  <chr>        <dbl>        <int>
+1 Fox            238            8
+2 Goat             1            9
+3 Hamster         14           10
+# A tibble: 3 × 3
+  animal_group count partition_id
+  <chr>        <dbl>        <int>
+1 Fox            238            8
+2 Goat             1            9
+3 Hamster         14            9
+# A tibble: 3 × 3
+  animal_group count partition_id
+  <chr>        <dbl>        <int>
+1 Fox            238            7
+2 Goat             1            8
+3 Hamster         14            8
+```
+````
+Although the same plan is being executed each time, the `partition_id` can be different. The `partition_id` is allocated by the [`.groupBy()`](https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.DataFrame.groupBy.html)/[`group_by()`](https://dplyr.tidyverse.org/reference/group_by.html) operation, which causes a shuffle.
+
+### Final thoughts
+
+Remember that sorting the data causes a [shuffle](../spark-concepts/shuffling), which is an expensive operation. Try and only sort data when necessary.
+
+Sometimes you do want your code to be non-deterministic, e.g. when using random numbers. You can set a seed to replicate results if needed. You may also want to use [mocking](../testing-debugging/unit-testing-pyspark.html#mocking) if unit testing in PySpark with random numbers.
+
 ### Further Resources
+
+Spark at the ONS Articles:
+- [Managing Partitions](../spark-concepts/partitions)
+- [Shuffling](../spark-concepts/shuffling)
+- [Sorting Spark DataFrames](../spark-functions/sorting-data)
+- [Unit Testing in PySpark](../testing-debugging/unit-testing-pyspark)
+    - [Mocking](../testing-debugging/unit-testing-pyspark.html#mocking)
+- [Unit Testing in sparklyr](../testing-debugging/unit-testing-sparklyr)
+- [Caching](../spark-concepts/cache)
+- [Writing Data](../spark-functions/writing-data)
+
+PySpark Documentation:
+- [`.show()`](https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.DataFrame.show.html)
+- [`F.spark_partition_id()`](https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.functions.spark_partition_id.html)
+- [`.groupBy()`](https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.DataFrame.groupBy.html)
+
+sparklyr and tidyverse Documentation:
+- [`group_by()`](https://dplyr.tidyverse.org/reference/group_by.html)
+- [`collect()`](https://dplyr.tidyverse.org/reference/compute.html)
+
+Spark SQL Functions Documentation:
+- [`spark_partition_id`](https://spark.apache.org/docs/latest/api/sql/index.html#spark_partition_id)

--- a/ons-spark/spark-functions/sorting-data.md
+++ b/ons-spark/spark-functions/sorting-data.md
@@ -1,0 +1,10 @@
+## Sorting Spark DataFrames
+
+```{warning}
+This section is under construction.
+```
+
+### Further Resources
+
+Spark at the ONS links:
+- [Spark DataFrames Are Not Ordered](../spark-concepts/df-order)

--- a/ons-spark/testing-debugging/unit-testing-pyspark.md
+++ b/ons-spark/testing-debugging/unit-testing-pyspark.md
@@ -4,6 +4,8 @@
 This section is under construction.
 ```
 
+### Mocking
+
 ### Further Resources
 
 Spark at the ONS links:


### PR DESCRIPTION
Mostly a migration of the existing tip, but I combined the partition id in with the first example to make things more compact without affecting the content.

If making any amendments to this be careful when running it that the examples are different - they could be the same and that wouldn't help with the explanation!

Also added a placeholder for an article on sorting data.