### PR TITLE
modifying cell metadata of tables going off the page

### DIFF
--- a/ons-spark/pyspark-intro/pyspark-intro.ipynb
+++ b/ons-spark/pyspark-intro/pyspark-intro.ipynb
@@ -221,7 +221,12 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true,
+    "tags": [
+     "output_scroll"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -887,7 +892,11 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "output_scroll"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -1779,8 +1788,9 @@
   }
  ],
  "metadata": {
+  "celltoolbar": "Edit Metadata",
   "kernelspec": {
-   "display_name": "Python 3.7.15 ('ons-spark-env-3.7')",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -1794,7 +1804,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.15"
+   "version": "3.8.3"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
issue #66 

Modified the metadata of certain cells. the addition to the cells metadata is simply adding ```"tags": ["output_scroll"]```. That is all. 

For review please build book and examine "intro to pyspark" page of the built book. To solve issue no tables should run off end of page. 

