### PR TITLE
Contributing guide

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,8 @@
+[bumpversion]
+current_version = 2022.5
+commit = True
+tag = True
+parse = (?P<year>\d+)\.(?P<build>\d+)
+serialize = {year}.{build}
+
+[bumpversion:file:ons-spark/_config.yml]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,11 +15,11 @@ jobs:
         os: [ubuntu-latest]
         python-version: [3.8]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Install dependencies
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,10 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements.txt
-
+    - name: increment_version
+      run: |
+        bump2version build
+        
     # Build the book
     - name: Build the book
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+    tags: 
+      - 'v*'
 
 # This job installs dependencies, build the book, and pushes it to `gh-pages`
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ This repository is built using a relatively complex set of dependencies, includi
 - R >=3.5,<4
 - git
 - Java Development Kit (for Spark) >=1.8.0_121
-- PySpark 3.2.3 (on Apache Spark 2.4).
+- PySpark >= 2.4.0
 - Sparklyr 1.8.0 (on Apache Spark 2.4)
 
 other versions of Spark 2 may be compatible but have not been tested. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Ready to contribute? Here's how to set up `Spark at the ONS` for local developme
 
 ## Environment Set-up
 
-This repository is built using a specific set of dependencies and both Python and R programming languages. To be able to appropriately modify the Jupyter Notebooks and convert them into markdown files (such that code tabs can be displayed to show demo code of both Python and R) and as a result an environment to have a full capability needs both Python and R. A list of environment requirements is below:
+This repository is built using a relatively complex set of dependencies, including both Python and R programming languages and Spark. A list of environment requirements is below:
 - Python >= 3.6 
 - R >=3.5,<4
 - git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,9 @@ spark = (SparkSession.builder.master("local[2]")
 ```
 An in a markdown cell right below you would have the following code:
 
-```r 
+
+```r
+``
 ```r
 library(sparklyr)
 library(dplyr)
@@ -108,7 +110,10 @@ sc <- sparklyr::spark_connect(
     master = "local[2]",
     config = sparklyr::spark_config())
 ```
+``
+
 ```
+
 
 
 Once you have correctly formatted the notebook it can then be converted into a markdown file by the converter. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ This repository is built using a relatively complex set of dependencies, includi
 - Python >= 3.6 
 - R >=3.5,<4
 - git
-- Java Development Kit (to be able to run Spark sessions)
+- Java Development Kit (for Spark) >=1.8.0_121
 - PySpark 3.2.3 (on Apache Spark 2.4).
 - Sparklyr 1.8.0 (on Apache Spark 2.4)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,9 @@ nb_maker = (markdown_from_notebook(in_path + "/" + page + ".ipynb",
 
 ```
 
+Once you have converted the notebook and the resulting files are stored in the right locations, you can now build the book with your new changes. 
+
+In the case that you are adding R code to a page in the book that is currently a Jupyter Notebook you will need to change the table of contents to point to the markdown file created by the conversion. To do this, inside the ons-spark folder modify the ```_toc.yml``` file such that the newly modified markdown file is included correctly. To learn a little more about Table of Contents in JupyterBooks see the Jupyter documentation [here](https://jupyterbook.org/en/stable/structure/toc.html)
 
 ## Code of Conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ Now all the appropriate dependencies should be installed we can now build the bo
 jb build ons-spark
 ```
 
-## Contributing to Notebooks to contaim both Python and R code
+## Contributing to Notebooks to contain both Python and R code
 
 The conversion of notebook files into markdown files that have code tabs to display both Python and R code requires the use of some of the functionality contained in the utilities file of this repo. 
 `notebook_converter.py` contains the function markdown_from_notebook that (as the name suggests) will convert a Jupyter Notebook into a Markdown file with appropriate code tabs, extract and run the R code, store both python and R outputs and put them in appropriate tabs in the notebook. This function takes as an argument the notebook that is to be converted and the output location of where you would like the resulting markdown file. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,14 @@ jb build ons-spark
 ## Contributing to Notebooks to contain both Python and R code
 
 The conversion of notebook files into markdown files that have code tabs to display both Python and R code requires the use of some of the functionality contained in the utilities folder of this repo. 
-`notebook_converter.py` contains the function markdown_from_notebook that (as the name suggests) will convert a Jupyter Notebook into a Markdown file with appropriate code tabs, extract and run the R code, store both python and R outputs and put them in appropriate tabs in the notebook. This function takes as an argument the notebook that is to be converted and the output location of where you would like the resulting markdown file. 
+`notebook_converter.py` contains the function markdown_from_notebook that (as the name suggests) will:
+
+- convert a Jupyter Notebook into a Markdown file with appropriate code tabs
+- extract and run the R code
+- store both python and R outputs and put them in appropriate tabs in the notebook. 
+
+This function takes as an argument the notebook that is to be converted and the output location of where you would like the resulting markdown file. 
+
 
 N.B. it is not neccessary to convert ALL notebooks, only ones that you would like to show code examples of both Python and R code. For example notebooks in the PySpark specific section (i.e. not relevant to Sparklyr and therefore not containing any R code) can remain as notebooks and JupyterBook will include them in the book without any issue. 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,8 +100,6 @@ spark = (SparkSession.builder.master("local[2]")
 An in a markdown cell right below you would have the following code:
 
 
-
-```r
 `` ```r
 library(sparklyr)
 library(dplyr)
@@ -112,7 +110,6 @@ sc <- sparklyr::spark_connect(
 ``` ``
 
 
-```
 
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ jb build ons-spark
 
 ## Contributing to Notebooks to contain both Python and R code
 
-The conversion of notebook files into markdown files that have code tabs to display both Python and R code requires the use of some of the functionality contained in the utilities file of this repo. 
+The conversion of notebook files into markdown files that have code tabs to display both Python and R code requires the use of some of the functionality contained in the utilities folder of this repo. 
 `notebook_converter.py` contains the function markdown_from_notebook that (as the name suggests) will convert a Jupyter Notebook into a Markdown file with appropriate code tabs, extract and run the R code, store both python and R outputs and put them in appropriate tabs in the notebook. This function takes as an argument the notebook that is to be converted and the output location of where you would like the resulting markdown file. 
 
 N.B. it is not neccessary to convert ALL notebooks, only ones that you would like to show code examples of both Python and R code. For example notebooks in the PySpark specific section (i.e. not relevant to Sparklyr and therefore not containing any R code) can remain as notebooks and JupyterBook will include them in the book without any issue. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,17 +100,17 @@ spark = (SparkSession.builder.master("local[2]")
 An in a markdown cell right below you would have the following code:
 
 
+
 ```r
-``
-```r
+`` ```r
 library(sparklyr)
 library(dplyr)
 
 sc <- sparklyr::spark_connect(
     master = "local[2]",
     config = sparklyr::spark_config())
-```
-``
+``` ``
+
 
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ This repository is built using a relatively complex set of dependencies, includi
 - git
 - Java Development Kit (for Spark) >=1.8.0_121
 - PySpark >= 2.4.0
-- Sparklyr 1.8.0 (on Apache Spark 2.4)
+- sparklyr >= 1.7.5
 
 other versions of Spark 2 may be compatible but have not been tested. 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ The conversion of notebook files into markdown files that have code tabs to disp
 
 N.B. it is not neccessary to convert ALL notebooks, only ones that you would like to show code examples of both Python and R code. For example notebooks in the PySpark specific section (i.e. not relevant to Sparklyr and therefore not containing any R code) can remain as notebooks and JupyterBook will include them in the book without any issue. 
 
-However, pages that contain code examples from both languages will be native Jupyter notebooks that have been converted using the convert in the utilities folder of this repo. An as a result the notebooks must be correctly formatted in order for the converter to work correctly. For any code that you wish to include in both languages, place the Python code in a code cell in the notebook as normal. Place the R code in a markdown cell directly below the Python code cell contained between `` ```r and ``` ``. 
+Pages that contain code examples in both Python and R have been converted using the above mentioned function in the utilities folder of this repo. And as a result the notebooks must be correctly formatted in order for the converter to work correctly. For any code that you wish to include in both languages, place the Python code in a code cell in the notebook as normal. Place the R code in a markdown cell directly below the Python code cell contained between `` ```r and ``` ``.  The notebook converter function uses these symbols as a marker to produce the R code tabs and R output tabs.
 
 For example, if you like the code to start a local spark session to be displayed in both Python and R, you would place the following in a code cell of a jupyter notebook:
 ```python 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,16 +99,16 @@ spark = (SparkSession.builder.master("local[2]")
 ```
 An in a markdown cell right below you would have the following code:
 
-
-`` ```r
+~~~
+```r
 library(sparklyr)
 library(dplyr)
 
 sc <- sparklyr::spark_connect(
     master = "local[2]",
     config = sparklyr::spark_config())
-``` ``
-
+``` 
+~~~
 
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,92 @@ Ready to contribute? Here's how to set up `Spark at the ONS` for local developme
 5. Commit your changes and push your branch to GitHub.
 6. Submit a pull request through the GitHub website.
 
+
+## Environment Set-up
+
+This repository is built using a specific set of dependencies and both Python and R programming languages. To be able to appropriately modify the Jupyter Notebooks and convert them into markdown files (such that code tabs can be displayed to show demo code of both Python and R) and as a result an environment to have a full capability needs both Python and R. A list of environment requirements is below:
+- Python >= 3.6 
+- R >=3.5,<4
+- git
+- Java Development Kit (to be able to run Spark sessions)
+- PySpark 3.2.3 (on Apache Spark 2.4).
+- Sparklyr 1.8.0 (on Apache Spark 2.4)
+
+other versions of Spark 2 may be compatible but have not been tested. 
+
+## Building the Book
+
+As mentioned in the README in the root of this repo. To build this book you'll need python installed. Once Python installed, then install its Python dependencies like so:
+
+```bash 
+git clone https://github.com/best-practice-and-impact/ons-spark.git
+cd ons-spark 
+pip install -r requirements.txt
+```
+
+Now all the appropriate dependencies should be installed we can now build the book locally. This is done by running the following command within the root of the repository. 
+
+```bash
+jb build ons-spark
+```
+
+## Contributing to Notebooks to contaim both Python and R code
+
+The conversion of notebook files into markdown files that have code tabs to display both Python and R code requires the use of some of the functionality contained in the utilities file of this repo. 
+`notebook_converter.py` contains the function markdown_from_notebook that (as the name suggests) will convert a Jupyter Notebook into a Markdown file with appropriate code tabs, extract and run the R code, store both python and R outputs and put them in appropriate tabs in the notebook. This function takes as an argument the notebook that is to be converted and the output location of where you would like the resulting markdown file. 
+
+N.B. it is not neccessary to convert ALL notebooks, only ones that you would like to show code examples of both Python and R code. For example notebooks in the PySpark specific section (i.e. not relevant to Sparklyr and therefore not containing any R code) can remain as notebooks and JupyterBook will include them in the book without any issue. 
+
+However, pages that contain code examples from both languages will be native Jupyter notebooks that have been converted using the convert in the utilities folder of this repo. An as a result the notebooks must be correctly formatted in order for the converter to work correctly. For any code that you wish to include in both languages, place the Python code in a code cell in the notebook as normal. Place the R code in a markdown cell directly below the Python code cell contained between `` ```r and ``` ``. 
+
+For example, if you like the code to start a local spark session to be displayed in both Python and R, you would place the following in a code cell of a jupyter notebook:
+```python 
+from pyspark.sql import SparkSession
+
+spark = (SparkSession.builder.master("local[2]")
+         .getOrCreate())
+
+```
+An in a markdown cell right below you would have the following code:
+
+```r 
+```r
+library(sparklyr)
+library(dplyr)
+
+sc <- sparklyr::spark_connect(
+    master = "local[2]",
+    config = sparklyr::spark_config())
+```
+```
+
+
+Once you have correctly formatted the notebook it can then be converted into a markdown file by the converter. 
+
+An example of the Python code required to accomplish this conversion can be seen in [convert](ons-spark\utilities\convert.py) but will be shown here. 
+
+In this example we would like to convert `checkpoint-staging.ipynb`. 
+
+```python
+group = "spark-concepts"
+folder = "checkpoint-staging"
+page = "checkpoint-staging"
+base_path = "/home/cdsw/ons-spark/ons-spark/"
+out_path = base_path + group
+
+in_path = base_path+"raw-notebooks/"+folder
+
+nb_maker = (markdown_from_notebook(in_path + "/" + page + ".ipynb",
+                                   out_path + "/" + page + ".md",
+                                   in_path + "/r_input.R",
+                                   in_path + "/outputs.csv",
+                                   show_warnings=False,
+                                   output_type="tabs")
+)
+
+```
+
+
 ## Code of Conduct
 
 Please note that the Spark at the ONS project is released with a [Contributor Code of Conduct](CONDUCT.md). By contributing to this project you agree to abide by its terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,40 @@ Once you have converted the notebook and the resulting files are stored in the r
 
 In the case that you are adding R code to a page in the book that is currently a Jupyter Notebook you will need to change the table of contents to point to the markdown file created by the conversion. To do this, inside the ons-spark folder modify the ```_toc.yml``` file such that the newly modified markdown file is included correctly. To learn a little more about Table of Contents in JupyterBooks see the Jupyter documentation [here](https://jupyterbook.org/en/stable/structure/toc.html). 
 
+
+## Publishing changes
+
+Internal contributors can trigger a new release of the book.
+
+### Preparation
+
+To create a new release and publish the `main` branch, you will need to install the dependencies:
+
+```
+pip install -r requirements.txt
+```
+
+### Releasing
+
+To create a new release, use the command line tool `bump2version`, which will be installed with the dev dependencies.
+The version number references the current `year` and an incremental `build` count.
+
+For a the first release of a year, provide the `year` as the command argument, otherwise provide `build`.
+
+```
+bump2version build
+```
+
+`bumpversion` will create a new Git `tag` and `commit`.
+If you're happy with the version increase, `push` these to the remote to trigger the publication, by running both:
+
+```
+git push
+git push --tags
+```
+
+
+
 ## Code of Conduct
 
 Please note that the Spark at the ONS project is released with a [Contributor Code of Conduct](CONDUCT.md). By contributing to this project you agree to abide by its terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ nb_maker = (markdown_from_notebook(in_path + "/" + page + ".ipynb",
 
 Once you have converted the notebook and the resulting files are stored in the right locations, you can now build the book with your new changes. 
 
-In the case that you are adding R code to a page in the book that is currently a Jupyter Notebook you will need to change the table of contents to point to the markdown file created by the conversion. To do this, inside the ons-spark folder modify the ```_toc.yml``` file such that the newly modified markdown file is included correctly. To learn a little more about Table of Contents in JupyterBooks see the Jupyter documentation [here](https://jupyterbook.org/en/stable/structure/toc.html)
+In the case that you are adding R code to a page in the book that is currently a Jupyter Notebook you will need to change the table of contents to point to the markdown file created by the conversion. To do this, inside the ons-spark folder modify the ```_toc.yml``` file such that the newly modified markdown file is included correctly. To learn a little more about Table of Contents in JupyterBooks see the Jupyter documentation [here](https://jupyterbook.org/en/stable/structure/toc.html). 
 
 ## Code of Conduct
 

--- a/ons-spark/_config.yml
+++ b/ons-spark/_config.yml
@@ -37,7 +37,7 @@ html:
   use_repository_button: true
   google_analytics_id: G-95MGHSRD0S
   #home_page_in_navbar: false
-  extra_navbar: "<p>Book version 2022.4</p>"
+  extra_navbar: "<p>Book version 2022.5</p>"
 
 
 # Our own added configs

--- a/ons-spark/_config.yml
+++ b/ons-spark/_config.yml
@@ -37,6 +37,8 @@ html:
   use_repository_button: true
   google_analytics_id: G-95MGHSRD0S
   #home_page_in_navbar: false
+  extra_navbar: "<p>Book version 2022.4</p>"
+
 
 # Our own added configs
 execute:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ matplotlib
 sphinx
 jupyter-book
 sphinx-tabs
+bump2version

--- a/utilities/convert.py
+++ b/utilities/convert.py
@@ -1,0 +1,20 @@
+#from utilities import markdown_from_notebook
+
+
+group = "spark-concepts"
+folder = "checkpoint-staging"
+page = "checkpoint-staging"
+base_path = "/home/cdsw/ons-spark/ons-spark/"
+out_path = base_path + group
+
+in_path = base_path+"raw-notebooks/"+folder
+
+nb_maker = (markdown_from_notebook(in_path + "/" + page + ".ipynb",
+                                   out_path + "/" + page + ".md",
+                                   in_path + "/r_input.R",
+                                   in_path + "/outputs.csv",
+                                   show_warnings=False,
+                                   output_type="tabs")
+)
+
+


### PR DESCRIPTION
Expanding the contributing document to include some description of how to include some guidance on how to convert notebooks to markdown files using the converter function and an example of how to convert. 

Also in this request is the versioning set up and included in the deploy action. No extra input needed from users to increment versioning as every time the action publishes the book it will increment the version and publish the next version. 

added a function to the requirements that is needed for the versioning. 

REVIEW:
Read CONTRIBUTING.md. Make sure it all makes sense. 
Look at the .github/workflows/deploy.yml file to examine that the publish commands are correct. I have modified the existing file that was in place but failing the deployment checks and modified it to I believe it to run OK. 


 