### PR TITLE
83 sparklyr avro

### DIFF
--- a/ons-spark/raw-notebooks/reading-and-writing-data/reading-and-writing-data-spark.ipynb
+++ b/ons-spark/raw-notebooks/reading-and-writing-data/reading-and-writing-data-spark.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -152,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -220,7 +220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,7 +260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,7 +289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -336,7 +336,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -362,7 +362,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -406,12 +406,14 @@
     "### Reading in Avro files\n",
     "To read in an Avro file using PySpark, you can use [`spark.read.format(\"avro\")`](https://sparkbyexamples.com/spark/read-write-avro-file-spark-dataframe/).\n",
     "\n",
-    "Please note: the Avro section for SparklyR is still under construction."
+    "Note that unlike other methods, Spark doesn't have a built in `spark.read.avro()` method so we need to use a slightly different method to read this in, by first specifying the format as \"avro\" and then using `.load()` to read in the file. Note that this method would also work for other formats, such as `spark.read.format(\"parquet\").load(...)` but is slightly more verbose than the other methods demonstrated. \n",
+    "\n",
+    "Using SparklyR, you will need to install the [`sparkavro`](https://cran.r-project.org/web/packages/sparkavro/) package and use the `spark_read_avro()` function. Note that this function requires three arguments: the spark connection name, a name to assign the newly read in table (in this case \"animal_rescue\"), and the path to the avro file."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -422,15 +424,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that unlike other methods, Spark doesn't have a built in `spark.read.avro()` method so we need to use a slightly different method to read this in, by first specifying the format as \"avro\" and then using `.load()` to read in the file. Note that this method would also work for other formats, such as `spark.read.format(\"parquet\").load(...)` but is slightly more verbose than the other methods demonstrated. \n",
+    "```r\n",
+    "library(sparkavro)\n",
+    "\n",
+    "animal_rescue = sparkavro::spark_read_avro(sc, \"animal_rescue\", config$rescue_path_avro)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
     "\n",
     "### Writing out Avro files\n",
-    "To write out an Avro file, you can use [`dataframe.write.format(\"avro\").save()`](https://sparkbyexamples.com/spark/read-write-avro-file-spark-dataframe/). Note that like the method to read in Avro files, we need to specify the format and then use `save` to specify that we want to save this out."
+    "To write out an Avro file, you can use [`dataframe.write.format(\"avro\").save()`](https://sparkbyexamples.com/spark/read-write-avro-file-spark-dataframe/). Note that like the method to read in Avro files, we need to specify the format and then use `save` to specify that we want to save this out.\n",
+    "\n",
+    "In SparklyR, we can use the `spark_write_avro()` function. This only requires two arguments: the name of the dataframe to be written to file and the output path. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -441,7 +456,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Also note that for this method, we pass in the mode as `write.mode(\"overwrite\")`. "
+    "```r\n",
+    "sparkavro::spark_write_avro(animal_rescue, paste0(config$temp_outputs, \"animal_rescue.avro\"), mode = \"overwrite\")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Also note that for these methods, we pass in the mode as `write.mode(\"overwrite\")`/`mode = \"overwrite\"`. "
    ]
   },
   {
@@ -466,7 +490,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -497,7 +521,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -515,7 +539,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/ons-spark/spark-overview/reading-and-writing-data-spark.md
+++ b/ons-spark/spark-overview/reading-and-writing-data-spark.md
@@ -495,22 +495,33 @@ An ORC file shares a lot of the same benefits that a parquet file has over a CSV
 ### Reading in Avro files
 To read in an Avro file using PySpark, you can use [`spark.read.format("avro")`](https://sparkbyexamples.com/spark/read-write-avro-file-spark-dataframe/).
 
-Please note: the Avro section for SparklyR is still under construction.
+Using SparklyR, you will need to install the [`sparkavro`](https://cran.r-project.org/web/packages/sparkavro/) package to use the `spark_read_avro()` function. Note that this function requires three arguments: the spark connection name, a name to assign the newly read in table (in this case "animal_rescue"), and the path to the avro file.
 ````{tabs}
 ```{code-tab} py
 animal_rescue = spark.read.format("avro").load(config["rescue_path_avro"])
+```
+```{code-tab} r R
+library(sparkavro)
+
+animal_rescue = sparkavro::spark_read_avro(sc, "animal_rescue", config$rescue_path_avro)
 ```
 ````
 Note that unlike other methods, Spark doesn't have a built in `spark.read.avro()` method so we need to use a slightly different method to read this in, by first specifying the format as "avro" and then using `.load()` to read in the file. Note that this method would also work for other formats, such as `spark.read.format("parquet").load(...)` but is slightly more verbose than the other methods demonstrated. 
 
 ### Writing out Avro files
-To write out an Avro file, you can use [`dataframe.write.format("avro").save()`](https://sparkbyexamples.com/spark/read-write-avro-file-spark-dataframe/). Note that like the method to read in Avro files, we need to specify the format and then use `save` to specify that we want to save this out.
+To write out an Avro file, you can use [`dataframe.write.format("avro").save()`](https://sparkbyexamples.com/spark/read-write-avro-file-spark-dataframe/) in PySpark. Note that like the method to read in Avro files, we need to specify the format and then use `save` to specify that we want to save this out.
+
+In SparklyR, we can use the `spark_write_avro()' function. This only requires two arguments; the name of the dataframe to be written to file and the output path. 
+
 ````{tabs}
 ```{code-tab} py
 animal_rescue.write.mode("overwrite").format("avro").save(config["temp_outputs"] + "animal_rescue.avro")
 ```
+```{code-tab} r R
+sparkavro::spark_write_avro(animal_rescue, paste0(config$temp_outputs, "animal_rescue.avro"), mode = "overwrite")
+```
 ````
-Also note that for this method, we pass in the mode as `write.mode("overwrite")`. 
+Also note that for these methods, we pass in the mode as `write.mode("overwrite")`/`mode = "overwrite"`. 
 
 While an Avro file has many of the benefits associated with parquet and ORC files, such as being associated with a schema and having built-in compression methods, there is one key difference:
 An Avro file is row-based, not column-based.

--- a/ons-spark/spark-overview/reading-and-writing-data-spark.md
+++ b/ons-spark/spark-overview/reading-and-writing-data-spark.md
@@ -495,7 +495,9 @@ An ORC file shares a lot of the same benefits that a parquet file has over a CSV
 ### Reading in Avro files
 To read in an Avro file using PySpark, you can use [`spark.read.format("avro")`](https://sparkbyexamples.com/spark/read-write-avro-file-spark-dataframe/).
 
-Using SparklyR, you will need to install the [`sparkavro`](https://cran.r-project.org/web/packages/sparkavro/) package to use the `spark_read_avro()` function. Note that this function requires three arguments: the spark connection name, a name to assign the newly read in table (in this case "animal_rescue"), and the path to the avro file.
+Note that unlike other methods, Spark doesn't have a built in `spark.read.avro()` method so we need to use a slightly different method to read this in, by first specifying the format as "avro" and then using `.load()` to read in the file. Note that this method would also work for other formats, such as `spark.read.format("parquet").load(...)` but is slightly more verbose than the other methods demonstrated. 
+
+Using SparklyR, you will need to install the [`sparkavro`](https://cran.r-project.org/web/packages/sparkavro/) package and use the `spark_read_avro()` function. Note that this function requires three arguments: the spark connection name, a name to assign the newly read in table (in this case "animal_rescue"), and the path to the avro file.
 ````{tabs}
 ```{code-tab} py
 animal_rescue = spark.read.format("avro").load(config["rescue_path_avro"])
@@ -506,12 +508,11 @@ library(sparkavro)
 animal_rescue = sparkavro::spark_read_avro(sc, "animal_rescue", config$rescue_path_avro)
 ```
 ````
-Note that unlike other methods, Spark doesn't have a built in `spark.read.avro()` method so we need to use a slightly different method to read this in, by first specifying the format as "avro" and then using `.load()` to read in the file. Note that this method would also work for other formats, such as `spark.read.format("parquet").load(...)` but is slightly more verbose than the other methods demonstrated. 
 
 ### Writing out Avro files
 To write out an Avro file, you can use [`dataframe.write.format("avro").save()`](https://sparkbyexamples.com/spark/read-write-avro-file-spark-dataframe/) in PySpark. Note that like the method to read in Avro files, we need to specify the format and then use `save` to specify that we want to save this out.
 
-In SparklyR, we can use the `spark_write_avro()' function. This only requires two arguments; the name of the dataframe to be written to file and the output path. 
+In SparklyR, we can use the `spark_write_avro()` function. This only requires two arguments: the name of the dataframe to be written to file and the output path. 
 
 ````{tabs}
 ```{code-tab} py

--- a/ons-spark/spark-overview/reading-and-writing-data-spark.md
+++ b/ons-spark/spark-overview/reading-and-writing-data-spark.md
@@ -510,7 +510,7 @@ animal_rescue = sparkavro::spark_read_avro(sc, "animal_rescue", config$rescue_pa
 ````
 
 ### Writing out Avro files
-To write out an Avro file, you can use [`dataframe.write.format("avro").save()`](https://sparkbyexamples.com/spark/read-write-avro-file-spark-dataframe/) in PySpark. Note that like the method to read in Avro files, we need to specify the format and then use `save` to specify that we want to save this out.
+To write out an Avro file, you can use [`dataframe.write.format("avro").save()`](https://sparkbyexamples.com/spark/read-write-avro-file-spark-dataframe/) in PySpark. Note that like the method to read in Avro files, we need to specify the format and then use `save` to specify that we want to save this output.
 
 In SparklyR, we can use the `spark_write_avro()` function. This only requires two arguments: the name of the dataframe to be written to file and the output path. 
 


### PR DESCRIPTION
Merge request template: please remove the appropriate parts of this template. 

Pre-merge request checklist (to be completed by the one making the request):
 - [x] I have performed a full review of this code myself.
    - For Python code in PySpark specific sections, all code should have been run in Jupyter notebooks. 
    - For code in sections of the book containing both Python and R code, the page of the book should be constructed as described in the [contributing guide](https://github.com/best-practice-and-impact/ons-spark/blob/main/CONTRIBUTING.md) and converted to a markdown file. 
 - [x] I have formatted the outputs of code blocks correctly (to match other outputs in the book and in line with the style guide [coming soon])
 - [x] I have built the book as outlined in the [contributing guide](https://github.com/best-practice-and-impact/ons-spark/blob/main/CONTRIBUTING.md) and confirmed that any additional/modified content is displaying as expected.


Details of this request:
- Adds sparklyr code and explanation of `spark_read_avro()`/`spark_write_avro()` to the reading and writing avro files section of the book.
- Closes issue #83 

Things to note about this request:
 - You will need to install the sparkavro r package (via `install.packages("sparkavro")`) before you can run the code.

Requirements for review (such as):
 - [ ] Check that avro files can be read and written correctly using the sparklyr code
 - [ ] Check that the explanations given make sense and are complete
 - [ ] Check that the link to the sparkavro r package on CRAN works correctly
 - [ ] Check that the page displays correctly
    - [ ] Check the code tabs work
    - [ ] Check for typos




